### PR TITLE
inlined home button styles

### DIFF
--- a/app/home.component.ts
+++ b/app/home.component.ts
@@ -3,7 +3,28 @@ import { HomeViewModel } from 'esri-mods';
 
 @Component({
   selector: 'esri-home',
-  template: '<a class="esri-home" href="#" (click)="onClick($event)"><i class="material-icons">home</i></a>'
+  template: '<a class="esri-home" href="#" (click)="onClick($event)"><i class="material-icons">home</i></a>',
+  styles: [
+`
+@import url('https://fonts.googleapis.com/icon?family=Material+Icons');
+.esri-home {
+  position: absolute;
+  right: 1em;
+  top: 1em;
+  padding: 1em;
+  color: rgba(255,255,255,1);
+}
+
+.esri-home:hover {
+  color: rgba(255,255,255,0.75);
+}
+
+.esri-home>i {
+  font-size: 3em;
+  text-shadow: 1px 1px 2px black; 
+}
+`
+  ]
 })
 export class HomeComponent {
 

--- a/css/main.css
+++ b/css/main.css
@@ -1,5 +1,4 @@
 @import url('https://js.arcgis.com/4.0beta3/esri/css/main.css');
-@import url('https://fonts.googleapis.com/icon?family=Material+Icons');
 html,
 body {
   padding: 0;
@@ -12,21 +11,4 @@ body {
   bottom: 1em;
   right: 1em;
   left: 1em;
-}
-
-.esri-home {
-  position: absolute;
-  right: 1em;
-  top: 1em;
-  padding: 1em;
-  color: rgba(255,255,255,1);
-}
-
-.esri-home:hover {
-  color: rgba(255,255,255,0.75);
-}
-
-.esri-home>i {
-  font-size: 3em;
-  text-shadow: 1px 1px 2px black; 
 }


### PR DESCRIPTION
makes this reusable component more portable

I actually wanted to use `styleUrls` and put the styles in app/home.component.css. I had that working with `styleUrls: ['app/home.component.css']` but that seemed to defeat the purpose (portability) so I tried getting ti work w/ beta.0's [support for relative urls](http://schwarty.com/2015/12/22/angular2-relative-paths-for-templateurl-and-styleurls/). Unfortunately, [I could not get that to work](https://github.com/angular/angular/issues/6053#issuecomment-166961267) so just inlined the styles.
