### PR TITLE
added content area to map view component

### DIFF
--- a/app/app.component.ts
+++ b/app/app.component.ts
@@ -8,8 +8,9 @@ import { HomeComponent } from './home.component';
     template:
     `
     <div>
-    <esri-map #mapView (viewCreated)="homeButton.setView(mapView.view)" ></esri-map>
-    <esri-home #homeButton></esri-home>
+    <esri-map #mapView (viewCreated)="homeButton.setView(mapView.view)">
+      <esri-home #homeButton></esri-home>
+    </esri-map>
     </div>
     `
 })

--- a/app/map.component.ts
+++ b/app/map.component.ts
@@ -4,7 +4,7 @@ import { MapView } from 'esri-mods';
 
 @Component({
     selector: 'esri-map',
-    template: '<div id="viewDiv"></div>',
+    template: '<div id="viewDiv"><ng-content></ng-content></div>',
     providers: [MapService]
 })
 export class MapComponent {


### PR DESCRIPTION
allows nesting of child components

In my [Angular 1 home button implementation](http://plnkr.co/edit/2QbrzR6shryLbE72So7n?p=preview), I used transclusion to enable nesting of the home button directive into the map view directive like so:

``` html
            <esri-scene-view map="exampleCtrl.map" on-create="exampleCtrl.onViewCreated">
                <my-home-button view-model="exampleCtrl.homeVM"></my-home-button>
            </esri-scene-view>
```

I liked the feel of that b/c the home button is overlaid on top of the map/scene, so I added the same here w/ ng-content (which replaces transclusion in Angular2), so the app component's template can look like:

``` html
    <esri-map #mapView (viewCreated)="homeButton.setView(mapView.view)">
      <esri-home #homeButton></esri-home>
    </esri-map>
```
